### PR TITLE
Issue 51

### DIFF
--- a/build_transtype-epub_template.xml
+++ b/build_transtype-epub_template.xml
@@ -139,7 +139,11 @@ for inclusion in the epub file -->
     <condition property="css.output.dir" value="${user.csspath}">
       <isset property="user.csspath" />
     </condition>
-
+    
+    <condition property="css.include.kindle" value="true">
+      <equals arg1="${d4p.include.kindle.css}" arg2="true"/>
+    </condition>
+    
   	<condition property="epub.hide.parent.link" value="yes">
   		<not>
       	<isset property="args.hide.parent.link" />
@@ -285,6 +289,9 @@ for inclusion in the epub file -->
     <antcall target="epub-copy-css-system"/>
     <!-- Copy user specified css file when required -->
     <antcall target="epub-copy-css-user"/>
+    
+    <!-- Copy kindle css if being triggered by the kindle plugin -->
+    <antcall target="epub-copy-css-kindle" />
   </target>
 
   <target name="epub-copy-css-system" unless="${system.copycss.no}">
@@ -297,5 +304,9 @@ for inclusion in the epub file -->
   <target name="epub-copy-css-user" if="user.copycss.yes">
     <copy file="${args.css.real}" todir="${user.csspath.real}"/>
   </target>
-
+  
+  <target name="epub-copy-css-kindle" if="css.include.kindle">
+    <copy file="${dita.plugin.org.dita4publishers.kindle.dir}/css/kindleExtensions.css" todir="${user.csspath.real}"/>
+  </target>
+  
 </project>

--- a/xsl/epubHtmlOverrides.xsl
+++ b/xsl/epubHtmlOverrides.xsl
@@ -3,13 +3,15 @@
   xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
   xmlns:xs="http://www.w3.org/2001/XMLSchema"
   xmlns:related-links="http://dita-ot.sourceforge.net/ns/200709/related-links"
-  exclude-result-prefixes="xs related-links"
+  xmlns:epubtrans="urn:d4p:epubtranstype"
+  exclude-result-prefixes="xs related-links epubtrans"
   version="2.0">
   
   <!-- Overrides of built-in HTML generation templates -->
   
   <!-- this template is copied from dita2htmlImpl.xsl in the DITA-OT's xhtml plugin -->
   <xsl:template name="generateCssLinks">
+    <xsl:param name="doDebug" as="xs:boolean" tunnel="yes" select="false()"/>
     <xsl:variable name="childlang">
       <xsl:choose>
         <!-- Update with DITA 1.2: /dita can have xml:lang -->
@@ -67,7 +69,14 @@
       </xsl:choose><xsl:value-of select="$newline"/>
     </xsl:if>
     
+    <xsl:apply-templates select="." mode="epubtrans:add-additional-css">
+      <xsl:with-param name="doDebug" as="xs:boolean" tunnel="yes" select="$doDebug"/>
+    </xsl:apply-templates>
+    
   </xsl:template>
+  
+  <xsl:template match="text()" mode="epubtrans:add-additional-css"/>
+    
   
   
 </xsl:stylesheet>


### PR DESCRIPTION
This is to support the new refactor of the kindle plugin by doing two things: if the kindle plugin is executing the plugin then it copies the kindleExtensions.css file (edit to build template) and by extending the epubHtmlOverride file to add an extension point for inclusion of arbitrary link elements in HTML head files.