### PR TITLE
Move base XHTML import to shell stylesheet

### DIFF
--- a/xsl/map2epubImpl.xsl
+++ b/xsl/map2epubImpl.xsl
@@ -58,8 +58,6 @@
 
   <xsl:import href="plugin:org.dita4publishers.common.xslt:xsl/reportParametersBase.xsl"/>
   <xsl:import href="plugin:org.dita4publishers.common.html:xsl/html-generation-utils.xsl"/>
-  <!-- Import the base HTML output generation transform. -->
-  <xsl:import href="plugin:org.dita.xhtml:xsl/dita2xhtml.xsl"/>
 
   <xsl:import href="plugin:org.dita4publishers.common.mapdriven:xsl/mapdrivenEnumerationD4P.xsl"/>
   <xsl:import href="plugin:org.dita4publishers.common.xslt:xsl/map2graphicMap.xsl"/>

--- a/xsl/map2epub_template.xsl
+++ b/xsl/map2epub_template.xsl
@@ -21,6 +21,7 @@ they will be added to the epub file as Dublin Core metadata.
                 exclude-result-prefixes="xs epub"
   >
 
+  <xsl:import href="plugin:org.dita.xhtml:xsl/dita2xhtml.xsl"/>
   <xsl:import href="map2epubImpl.xsl"/>
   
 


### PR DESCRIPTION
This makes custom shells easier because only map2epubImpl.xsl needs to be imported by custom shells.

Signed-off-by: Jarno Elovirta <jarno@elovirta.com>