### PR TITLE
Add missing filters for debug log messages

### DIFF
--- a/xsl/map2epubBookmapImpl.xsl
+++ b/xsl/map2epubBookmapImpl.xsl
@@ -113,7 +113,9 @@
   </xsl:template>
   
   <xsl:template mode="generate-book-lists" match="*[df:class(., 'bookmap/toc')][not(@href)]" priority="10">
-    <xsl:message> + [DEBUG] generate-book-lists: bookmap/toc</xsl:message>
+    <xsl:if test="$debugBoolean">
+      <xsl:message> + [DEBUG] generate-book-lists: bookmap/toc</xsl:message>
+    </xsl:if>
     <xsl:variable name="htmlFilename" as="xs:string"
       select="concat('toc_', generate-id(.), $outext)"
     />

--- a/xsl/map2epubD4PImpl.xsl
+++ b/xsl/map2epubD4PImpl.xsl
@@ -140,7 +140,9 @@
   </xsl:template>
  
   <xsl:template mode="generate-book-lists" match="*[df:class(., 'pubmap-d/toc')][not(@href)]" priority="10">
-    <xsl:message> + [DEBUG] generate-book-lists: pubmap-d/toc</xsl:message>
+    <xsl:if test="$debugBoolean">
+      <xsl:message> + [DEBUG] generate-book-lists: pubmap-d/toc</xsl:message>
+    </xsl:if>
     <xsl:variable name="htmlFilename" as="xs:string"
       select="concat('toc_', generate-id(.), $outext)"
     />

--- a/xsl/map2epubIndexImpl.xsl
+++ b/xsl/map2epubIndexImpl.xsl
@@ -49,7 +49,9 @@
                 group-by="local:construct-index-group-key(.)"
                 >
                 <xsl:sort select="local:construct-index-group-sort-key(.)"/>
-                <xsl:message> + [DEBUG] Index group "<xsl:sequence select="current-grouping-key()"/>"</xsl:message>
+                <xsl:if test="$debugBoolean">
+                  <xsl:message> + [DEBUG] Index group "<xsl:sequence select="current-grouping-key()"/>"</xsl:message>
+                </xsl:if>
                 <div class="index-group">
                   <h2><xsl:sequence select="local:construct-index-group-label(current-group()[1])"/></h2>
                   <ul class="index-terms">

--- a/xsl/map2epubOpfImpl.xsl
+++ b/xsl/map2epubOpfImpl.xsl
@@ -155,7 +155,9 @@
             <xsl:with-param name="effectiveCoverGraphicUri" select="$effectiveCoverGraphicUri" as="xs:string" tunnel="yes"/>
           </xsl:apply-templates>
         </xsl:variable>
-        <xsl:message> + [DEBUG] $isEncryptionRequired="<xsl:value-of select="$isEncryptionRequired"/>"</xsl:message>
+        <xsl:if test="$debugBoolean">
+          <xsl:message> + [DEBUG] $isEncryptionRequired="<xsl:value-of select="$isEncryptionRequired"/>"</xsl:message>
+        </xsl:if>
         <xsl:if test="$isEncryptionRequired">
           <xsl:message> + [INFO] Generating encryption.xml file...</xsl:message>
           <xsl:call-template name="epubtrans:makeEncryptionXml">
@@ -1081,7 +1083,7 @@
       <xsl:apply-templates select="$context" mode="include-topicref-in-spine"/>
     </xsl:variable>
     <xsl:variable name="result" as="xs:boolean" select="$test = 'true'"/>
-    <xsl:if test="$result and true()">
+    <xsl:if test="$result and $debugBoolean and true()">
       <xsl:message> + [DEBUG] local:includeTopicrefInSpine: Including element "<xsl:sequence select="name($context)"/>" in spine.</xsl:message>
     </xsl:if>
     <xsl:sequence select="$result"/>
@@ -1093,7 +1095,7 @@
       <xsl:apply-templates select="$context" mode="include-topicref-in-manifest"/>
     </xsl:variable>
     <xsl:variable name="result" as="xs:boolean" select="$test = 'true'"/>
-    <xsl:if test="$result and false()">
+    <xsl:if test="$result and $debugBoolean and false()">
       <xsl:message> + [DEBUG] local:includeTopicrefInSpine: Including element "<xsl:sequence select="name($context)"/>" in manifest.</xsl:message>
     </xsl:if>
     <xsl:sequence select="$result"/>

--- a/xsl/map2epubSetCoverGraphic.xsl
+++ b/xsl/map2epubSetCoverGraphic.xsl
@@ -43,7 +43,9 @@
           <xsl:variable name="targetUri" as="xs:string"
             select="df:getEffectiveTopicUri((//*[df:class(., 'pubmap-d/epub-cover-graphic')])[1])"
           />
-          <xsl:message> + [DEBUG] found pubmap-d/epub-cover-graphic, targetUri="<xsl:sequence select="$targetUri"/>"</xsl:message>
+          <xsl:if test="$debugBoolean">
+            <xsl:message> + [DEBUG] found pubmap-d/epub-cover-graphic, targetUri="<xsl:sequence select="$targetUri"/>"</xsl:message>
+          </xsl:if>
           <xsl:sequence select="$targetUri"/>
         </xsl:when>
         <xsl:when test="*[df:class(., 'map/topicmeta')]//*[df:class(., 'topic/data') and @name = 'covergraphic']">

--- a/xsl/map2epubTocImpl.xsl
+++ b/xsl/map2epubTocImpl.xsl
@@ -426,7 +426,9 @@
         <xsl:sequence select="false()"/>
       </xsl:when>
       <xsl:when test="$context/ancestor::*[contains(@chunk, 'to-content')]">
-        <xsl:message> + [DEBUG] isNavPoint(): ancestor has @chunk with to-content.</xsl:message>
+        <xsl:if test="$debugBoolean">
+          <xsl:message> + [DEBUG] isNavPoint(): ancestor has @chunk with to-content.</xsl:message>
+        </xsl:if>
         <xsl:sequence select="false()"/>
       </xsl:when>
       <xsl:when test="string($context/@toc) = 'no'"><!-- Issue 3331319: @toc not respected in EPUB ToC -->


### PR DESCRIPTION
Add missing `xsl:if` around log messages to filter out debug level messages.

Signed-off-by: Jarno Elovirta <jarno@elovirta.com>