### PR TITLE
Update xsl:output statement for method xhtml

### DIFF
--- a/xsl/map2epubImpl.xsl
+++ b/xsl/map2epubImpl.xsl
@@ -408,8 +408,7 @@
   <xsl:output name="html5" method="xhtml"
     indent="yes"
     encoding="utf-8"
-    doctype-system="about:legacy-compat"
-    omit-xml-declaration="yes"
+    omit-xml-declaration="no"
     include-content-type="no"
   />
 


### PR DESCRIPTION
This change avoids a problem with Kindle readers getting confused by the lack of a character set declaration.